### PR TITLE
ssh-add without an identity

### DIFF
--- a/bin/doubledown
+++ b/bin/doubledown
@@ -53,10 +53,8 @@ then
 		trap 'eval $(ssh-agent -k)' 0
 	fi
 
-	if [ -z "$IDENTITY" ]
+	if [ -n "$IDENTITY" ]
 	then
-		ssh-add
-	else
 		ssh-add "$IDENTITY"
 	fi
 


### PR DESCRIPTION
Hey Guys,

This is possibly the simplest code change ever, but I'm not sure why three is a call to ssh-add without an identity. AFAIK ssh-add without an argument always returns 1, which stops the dropdown process before it gets started.

I made a super simple patch that let's old crufty tcsh users join in the doubledown fun.

Best,

-Erik
