### PR TITLE
Force ssh-agent to output 'sh' commands

### DIFF
--- a/bin/doubledown
+++ b/bin/doubledown
@@ -53,10 +53,8 @@ then
 		trap 'eval $(ssh-agent -k)' 0
 	fi
 
-	if [ -z "$IDENTITY" ]
+	if [ -n "$IDENTITY" ]
 	then
-		ssh-add
-	else
 		ssh-add "$IDENTITY"
 	fi
 

--- a/bin/doubledown
+++ b/bin/doubledown
@@ -49,8 +49,8 @@ then
 		[ -n "$SSH_AGENT_PID" ] && export SSH_AGENT_PID
 		export SSH_AUTH_SOCK
 	else
-		eval $(ssh-agent)
-		trap 'eval $(ssh-agent -k)' 0
+		eval $(ssh-agent -s)
+		trap 'eval $(ssh-agent -sk)' 0
 	fi
 
 	[ -n "$IDENTITY" ] && ssh-add "$IDENTITY" || ssh-add || {


### PR DESCRIPTION
Right now, ssh-agent is returning commands based on the user's shell. This simple patch enables tcsh users to use doubledown without an existing ssh-agent.
